### PR TITLE
Removeformat in TinyMCE

### DIFF
--- a/module/Core/src/Core/Form/View/Helper/FormEditor.php
+++ b/module/Core/src/Core/Form/View/Helper/FormEditor.php
@@ -137,7 +137,7 @@ class FormEditor extends FormTextarea
     protected function additionalOptions()
     {
         return '
-        toolbar: "undo redo | formatselect | bold italic | alignleft aligncenter alignright alignjustify | link | bullist",
+        toolbar: "undo redo | formatselect | bold italic | alignleft aligncenter alignright alignjustify | link | bullist | removeformat",
         menubar: false,
         advlist_bullet_styles: "square disc",
         block_formats: "Headings=h4;",

--- a/module/Core/src/Core/Form/View/Helper/FormEditorLight.php
+++ b/module/Core/src/Core/Form/View/Helper/FormEditorLight.php
@@ -20,7 +20,7 @@ class FormEditorLight extends FormEditor
     
     protected function additionalOptions() {
         return '
-        toolbar: "undo redo | formatselect | alignleft aligncenter alignright",
+        toolbar: "undo redo | formatselect | alignleft aligncenter alignright | removeformat",
         menubar: false,
         block_formats: "Job title=h1;Subtitle=h2",
         '.$this->additionalLanguageOptions();

--- a/module/Jobs/public/templates/classic/index.phtml
+++ b/module/Jobs/public/templates/classic/index.phtml
@@ -74,7 +74,7 @@
                 <address>
                     <strong><?php echo $this->organizationName?><br></strong>
                     <?php echo $this->street?><br>
-                    <?php echo $this->zipcode?> <?php echo $this->city?><br><br>
+                    <?php echo $this->postalCode?> <?php echo $this->city?><br><br>
                     <?php echo $this->phone?>
                 </address>
             </div>

--- a/module/Jobs/public/templates/default/index.phtml
+++ b/module/Jobs/public/templates/default/index.phtml
@@ -63,7 +63,7 @@
                     </strong><br/>
                     <address itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
                         <span itemprop="streetAddress"><?php echo $this->street?></span><br>
-                        <span itemprop="postalCode"><?php echo $this->zipcode?></span>
+                        <span itemprop="postalCode"><?php echo $this->postalCode?></span>
                         <span itemprop="addressLocality"><?php echo $this->city?></span>
                         <br><br>
                         <span itemprop="telephone"><?php echo $this->phone?></span>

--- a/module/Jobs/public/templates/modern/index.phtml
+++ b/module/Jobs/public/templates/modern/index.phtml
@@ -36,7 +36,7 @@
                     <address>
                         <strong><?php echo $this->organizationName?><br></strong>
                         <?php echo $this->street?><br>
-                        <?php echo $this->zipcode?> <?php echo $this->city?><br><br>
+                        <?php echo $this->postalCode?> <?php echo $this->city?><br><br>
                         <?php echo $this->phone?>
                     </address>
                 </div>


### PR DESCRIPTION
Allowing past form e.g. Word can lead to situations where formats are entered but cannot be (easily) removed. Adding the removeformat option allows to clean up.

I only wanted to request a pull of the last two commits. But I did not manage to select only those. Sorry.