### PR TITLE
CoreTestUtils standalone repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
         "zendframework/zend-cache": "^2.7",
         "zendframework/zend-captcha": "^2.7",
         "zendframework/zend-feed": "^2.8",
+
         "zendframework/zend-form": "^2.10",
         "zendframework/zend-i18n-resources": "^2.5",
         "zendframework/zend-json": "^3.0",

--- a/module/Core/test/CoreTestUtils/LICENSE
+++ b/module/Core/test/CoreTestUtils/LICENSE
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Copyright (c) 2013-present CROSS Solution
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/module/Core/test/CoreTestUtils/README.md
+++ b/module/Core/test/CoreTestUtils/README.md
@@ -1,0 +1,3 @@
+Yawik Core Test Utils
+====
+This project contains a set of test library for Yawik phpunit tests. 

--- a/module/Core/test/CoreTestUtils/composer.json
+++ b/module/Core/test/CoreTestUtils/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "yawik/core-test-utils",
+    "description": "Yawik Core Test Utils",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Anthonius Munthi",
+            "email": "me@itstoni.com"
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-develop": "0.33-dev"
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "CoreTestUtils\\": ""
+        }
+    },
+    "require": {
+        "phpunit/phpunit": "^7.5.8 | ^8.1.2"
+    }
+}

--- a/module/ReleaseTools/bin/subsplit.sh
+++ b/module/ReleaseTools/bin/subsplit.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#!/usr/bin/env bash
 #
 # git-subsplit.sh: Automate and simplify the process of managing one-way
 # read-only subtree splits.

--- a/module/ReleaseTools/src/Console/SubsplitController.php
+++ b/module/ReleaseTools/src/Console/SubsplitController.php
@@ -151,11 +151,19 @@ class SubsplitController extends AbstractConsoleController
         /* @var \Symfony\Component\Finder\SplFileInfo $directory */
         foreach ($finder->directories() as $directory) {
             $moduleName = $directory->getRelativePathname();
+            if('ReleaseTools' === $moduleName){
+                continue;
+            }
             $tree[$moduleName] = [
                 'path' => 'module/'.$moduleName,
                 'repo' => $target.'/'.Inflector::tableize($moduleName).'.git'
             ];
         }
+
+        $tree['CoreTestUtils'] = [
+            'path' => 'module/Core/test/CoreTestUtils',
+            'repo' => $target.'/core-test-utils.git'
+        ];
         ksort($tree);
         $this->tree = $tree;
     }


### PR DESCRIPTION
This pull request will make CoreTestUtils to be subsplit into:
https://github.com/yawik/CoreTestUtils
and also make CoreTestUtils to be available as composer package: ```yawik/core-test-utils```