### PR TITLE
infoCheckbox for application carbon copy

### DIFF
--- a/module/Applications/src/Form/Attributes.php
+++ b/module/Applications/src/Form/Attributes.php
@@ -30,7 +30,7 @@ class Attributes extends Form
 
         $this->add(
             array(
-            'type' => 'checkbox',
+            'type' => 'infoCheckBox',
             'name' => 'sendCarbonCopy',
             'options' => array(
                 'headline' => /*@translate*/ 'Carbon Copy',


### PR DESCRIPTION
Im Bewerbungsformular fehlt das Label für "carbonCopy". Es wird nur die Checkbox dargestellt.
Um das Label anzuzeigen, habe ich den Typ von Checkbox zu infoCheckBox geändert.

