### PR TITLE
Router script for internal php server

### DIFF
--- a/public/.gitignore
+++ b/public/.gitignore
@@ -7,6 +7,7 @@
 !.gitignore
 !.htaccess
 !index.php
+!router.php
 !images
 !css
 !css/*.css

--- a/public/router.php
+++ b/public/router.php
@@ -1,0 +1,10 @@
+<?php
+
+if (false === strpos($_SERVER['REQUEST_URI'], '.')
+    || is_file($_SERVER['DOCUMENT_ROOT'] . '/' . $_SERVER['SCRIPT_NAME'])
+) {
+    return false;
+}
+
+$_SERVER['SCRIPT_NAME'] = '/index.php';
+require __DIR__ . "/index.php";


### PR DESCRIPTION
When developing with the internal php server, all Urls containing a "."
are considered files by the server.
This leads to errors in YAWIK, because some url routes contain dots.
The router script checks, if a file exists and "redirects" all other
cases to the "index.php"

Usage is:
php -S localhost:8000 -t public/ public/router.php