### PR TITLE
AUTH module: change condition for loading more users (switch user)

### DIFF
--- a/module/Auth/view/auth/index/login-info.phtml
+++ b/module/Auth/view/auth/index/login-info.phtml
@@ -166,7 +166,7 @@ $lang = isset($this->lang)?$this->lang:$defaultLang; ?>
                                 return {
                                     results: data.items,
                                     pagination: {
-                                        more: params.page * 20 < data.total
+                                        more: params.page * 10 < data.total
                                     }
                                 };
                             }


### PR DESCRIPTION
Hallo,

momentan existiert ein Bug. Wenn ein Admin den "Benutzer wechseln" möchte, erscheinen in der Liste nicht alle Nutzer. Das liegt daran, dass die more Condition den Faktor 20 erhält. Hier müsste der Wert pagePerItem ausgelesen werden.
Als Standard ist der Wert für pagePerItem = 10. Deshalb habe ich den Faktor angepasst. 
Das könnte eventuell auch der Grund für das Issue 408 sein (https://github.com/cross-solution/YAWIK/issues/408)