### PR TITLE
fix(Core): refine phone number validation

### DIFF
--- a/module/Core/src/Form/Element/Phone.php
+++ b/module/Core/src/Form/Element/Phone.php
@@ -21,9 +21,9 @@ class Phone extends Element implements InputProviderInterface
     public function getValidator()
     {
         if (null === $this->validator) {
-            $validator = new RegexValidator('/^([\+][0-9]{1,3}[ \.\-])?([\(]{1}[0-9]{1,6}[\)])?([0-9 \.\-\/]{3,20})((x|ext|extension)[ ]?[0-9]{1,4})?$/');
+            $validator = new RegexValidator('~^(\+\d\d)?[0-9 ()]+$~');
             $validator->setMessage(
-                /*@translate */ 'Please enter a phone Number. You can use the intenational format. Only digits and \'+\'.',
+                /*@translate */ 'Please enter a phone Number. May start with \'+\'. Only digits, \'(\', \')\' and \' \'.',
                 RegexValidator::NOT_MATCH
             );
 


### PR DESCRIPTION
Entering a phone number via the Phone form element required a very specific format.

This PR allows a more flexible format. A phone number can now contain digits, parentheses and spaces. Also the international format is valid still - but it doesn't matter if the country prefix is followed by a space.

