### PR TITLE
fix: Application carbon copy could not be send

### DIFF
--- a/module/Applications/config/module.config.php
+++ b/module/Applications/config/module.config.php
@@ -249,12 +249,12 @@ return [
     'mails' => [
         'invokables' => [
             'Applications/StatusChange'   => 'Applications\Mail\StatusChange',
-            'Applications/CarbonCopy'     => 'Applications\Mail\ApplicationCarbonCopy',
         ],
         'factories' => [
             'Applications/NewApplication' => 'Applications\Factory\Mail\NewApplicationFactory',
             Mail\Confirmation::class      => Factory\Mail\ConfirmationFactory::class,
-            'Applications/Forward'        => [Forward::class,'factory'],
+            'Applications/Forward'        => Factory\Mail\ForwardFactory::class,
+            'Applications/CarbonCopy'     => Factory\Mail\ForwardFactory::class,
         ],
         'aliases' => [
             'Applications/Confirmation'   => Mail\Confirmation::class,

--- a/module/Applications/src/Factory/Mail/ForwardFactory.php
+++ b/module/Applications/src/Factory/Mail/ForwardFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * YAWIK
+ *
+ * @see       https://github.com/cross-solution/YAWIK for the canonical source repository
+ * @copyright https://github.com/cross-solution/YAWIK/blob/master/COPYRIGHT
+ * @license   https://github.com/cross-solution/YAWIK/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Applications\Factory\Mail;
+
+use Applications\Entity\Attachment;
+use Applications\Mail\ApplicationCarbonCopy;
+use Applications\Mail\Forward;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Factory for \Applications\Mail\Forward
+ *
+ * @author Mathias Gelhausen
+ */
+class ForwardFactory
+{
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null
+    ): Forward {
+        $class = strpos($requestedName, 'Copy') === false ? Forward::class : ApplicationCarbonCopy::class;
+
+        return new $class(
+            $container->get('ViewHelperManager'),
+            $container->get('repositories')->get(Attachment::class),
+            $options
+        );
+    }
+}


### PR DESCRIPTION
* getResource() method on entities is no longer supported in Doctrine 2.x.
  instead the 'downloadToStream' or 'openDownloadStream' of the corresponding
  REPOSITORY must be used instead.

* Move inline factory of \Applications\Mail\Forward to an external factory.

[ refs #636 ]